### PR TITLE
Make vault a regular dependency

### DIFF
--- a/ecs_compose.gemspec
+++ b/ecs_compose.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "docopt", "~> 0.5.0"
   spec.add_dependency "colorize", "~> 0.7.7"
-
-  spec.add_development_dependency "vault", "~> 0.1.5"
+  spec.add_dependency "vault", "~> 0.1.5"
+  
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
We could try making this a regular dependency instead of a dev dependency. I think there's some magic that tries to do the right thing if vault isn't installed, so that this didn't need to always be enabled (or something like that), but I don't have the time to figure it out. Anyway, it's possible this might help.

CC @seamusabshere @dkastner